### PR TITLE
Update README with simpler OSX instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ Gameplay differences from the original 2048 game:
 - Total score is not calculated.
 - New cells are populated only with 2's, instead of having a small chance of a 4 appearing.
 
-> Note for OS X users: The version of sed installed has different options than the Linux one. Notably, it does not have the extended-regex option `-r`. I recommend building the latest version from here: http://sed.sourceforge.net/
+> Note for OS X users: The version of sed installed by default has different options than the Linux one. Notably, it does not have the extended-regex option `-r`. A compatible version is available through [homebrew](http://brew.sh/): `brew install gnu-sed --default-names` (the `--default-names` flag is used to ensure it installs as `sed` and not `gsed`). You can also build the latest version from here: http://sed.sourceforge.net/


### PR DESCRIPTION
Getting a compatible version of sed is made very easy with homebrew (which is widely used). I updated the README's OSX note with instructions, as the "default-names" flag isn't too well known.
