### PR TITLE
add: link to replit run

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "bash"
+run = "./src/2048.sh"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 ========
 
 [![Build Status](https://travis-ci.org/themattrix/sed2048.svg?branch=master)](https://travis-ci.org/themattrix/sed2048)
+[![run on repl.it](http://repl.it/badge/github/themattrix/sed2048)](https://repl.it/github/themattrix/sed2048)
 
 This is a sed implementation of the [2048 game](http://gabrielecirulli.github.io/2048/). All of the game logic is in sed. Bash is used to supply the sed script with user input and with pseudo-random numbers.
 


### PR DESCRIPTION
i think it would be pretty cool to let people see how this code works (and edit / preview the program) right in their browser, without any manual downloads or installation. i'm thinking we can add a 'run on repl.it' button, which redirects to something like [this](https://repl.it/@eankeen/run-sed2048):

![image](https://i.imgur.com/HC0oH3Q.png)

i suppose the web terminal emulator isn't behaving as we would expect, but it could possibly work by the time you see this
